### PR TITLE
Fixed checkAll() method

### DIFF
--- a/src/Wisdom/Wisdom.php
+++ b/src/Wisdom/Wisdom.php
@@ -60,6 +60,7 @@ class Wisdom
     {
         return When::map($domains, array($this, 'check'))
             ->then(function ($statuses) use ($domains) {
+                ksort($statuses);
                 return array_combine($domains, $statuses);
             });
 


### PR DESCRIPTION
The checkAll() was not combining the statuses with the domains in the correct order.  The $statuses array is returned in a random order, but the function assumed it was in the same order as the $domains array.  The keys in $statuses are correct, so the array just needed to be re-ordered.

Alternatively, the two arrays could be combined by key.
